### PR TITLE
Run version check asynchronously to avoid blocking mod initialization

### DIFF
--- a/src/main/java/com/seniors/justlevelingfork/JustLevelingFork.java
+++ b/src/main/java/com/seniors/justlevelingfork/JustLevelingFork.java
@@ -34,6 +34,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -84,12 +85,16 @@ public class JustLevelingFork {
         ServerNetworking.init();
 
         // Check for new updates
-        if (HandlerCommonConfig.HANDLER.instance().checkForUpdates) {
+    if (HandlerCommonConfig.HANDLER.instance().checkForUpdates) {
+        CompletableFuture.runAsync(() -> {
             try {
                 String version = getLatestVersion();
-
-                Optional<IModInfo> optionalModInfo = ModList.get().getMods().stream().filter(c -> Objects.equals(c.getModId(), MOD_ID)).findFirst();
-
+    
+                Optional<IModInfo> optionalModInfo = ModList.get().getMods()
+                        .stream()
+                        .filter(c -> Objects.equals(c.getModId(), MOD_ID))
+                        .findFirst();
+                
                 // Is this somehow isn't present then some really strange shit happen
                 if (optionalModInfo.isPresent()) {
                     ModInfo modInfo = (ModInfo) optionalModInfo.get();
@@ -100,9 +105,9 @@ public class JustLevelingFork {
                     }
                 }
             } catch (Exception e) {
-                LOGGER.warn(">> Error checking for updates!");
+                LOGGER.warn(">> Error checking for updates!", e);
             }
-        }
+        });
     }
 
     @NotNull


### PR DESCRIPTION
## PR Description

**What this PR does:**
This PR moves the mod version check to an asynchronous thread to prevent blocking the main initialization thread during mod loading.

---

### Original code (inside `JustLevelingFork` constructor)

```java
// Check for new updates
if (HandlerCommonConfig.HANDLER.instance().checkForUpdates) {
    try {
        String version = getLatestVersion();

        Optional<IModInfo> optionalModInfo = ModList.get().getMods().stream()
                .filter(c -> Objects.equals(c.getModId(), MOD_ID))
                .findFirst();

        // Is this somehow isn't present then some really strange shit happen
        if (optionalModInfo.isPresent()) {
            ModInfo modInfo = (ModInfo) optionalModInfo.get();
            if (!Objects.equals(modInfo.getVersion().toString(), version)) {
                UpdatesAvailable.left = true;
                UpdatesAvailable.right = version;
                LOGGER.info(">> NEW VERSION AVAILABLE: {}", version);
            }
        }
    } catch (Exception e) {
        LOGGER.warn(">> Error checking for updates!");
    }
}
```

---

### Why this is problematic

1. **Synchronous network request in the constructor**

   * `getLatestVersion()` opens a `URLConnection` to fetch the `VERSION` file from GitHub.
   * This is a network IO operation and can take several seconds or more if the network is slow or GitHub responds slowly.

2. **Forge/FML initialization runs on the main thread**

   * Mod initialization (constructors, event registration, item registration, etc.) happens on the main initialization thread.
   * If this network request blocks, it can freeze the entire mod loading process, making the game appear unresponsive.

3. **Violates best practices**

   * Minecraft/Forge strongly recommends that any long-running or blocking operations (network, file IO, heavy computations) should run asynchronously.
   * The main thread should only perform quick registration or initialization tasks.

---

### Summary

The problem is that the version check uses a network request **synchronously on the main thread**, which may cause long delays during mod initialization.

**This PR fixes the issue by running the version check asynchronously** (using `CompletableFuture.runAsync`) so it does not block the main thread.


